### PR TITLE
Removing favourite functionality

### DIFF
--- a/FresaClub.abi
+++ b/FresaClub.abi
@@ -43,44 +43,6 @@
 		"type": "function"
 	},
 	{
-		"inputs": [
-			{
-				"internalType": "uint256",
-				"name": "index",
-				"type": "uint256"
-			}
-		],
-		"name": "readFavourite",
-		"outputs": [
-			{
-				"internalType": "address",
-				"name": "storefront",
-				"type": "address"
-			}
-		],
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "address payable",
-				"name": "_storeFront",
-				"type": "address"
-			}
-		],
-		"name": "readFavouriteCount",
-		"outputs": [
-			{
-				"internalType": "uint256",
-				"name": "FavouriteCount",
-				"type": "uint256"
-			}
-		],
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
 		"inputs": [],
 		"name": "readFresaProductCount",
 		"outputs": [
@@ -294,30 +256,6 @@
 		"inputs": [
 			{
 				"internalType": "address",
-				"name": "_storefront",
-				"type": "address"
-			},
-			{
-				"internalType": "uint256",
-				"name": "_index",
-				"type": "uint256"
-			}
-		],
-		"name": "readProductExists",
-		"outputs": [
-			{
-				"internalType": "bool",
-				"name": "productExists",
-				"type": "bool"
-			}
-		],
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "address",
 				"name": "_storeFront",
 				"type": "address"
 			}
@@ -366,38 +304,6 @@
 			}
 		],
 		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "address",
-				"name": "_storeFront",
-				"type": "address"
-			}
-		],
-		"name": "readStoreFrontExisits",
-		"outputs": [
-			{
-				"internalType": "bool",
-				"name": "",
-				"type": "bool"
-			}
-		],
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"internalType": "address",
-				"name": "_storefront",
-				"type": "address"
-			}
-		],
-		"name": "writeFavourite",
-		"outputs": [],
-		"stateMutability": "nonpayable",
 		"type": "function"
 	},
 	{

--- a/FresaClub.sol
+++ b/FresaClub.sol
@@ -199,35 +199,6 @@
                 return productCount[_storeFront];
         }
 
-        struct Favourite{
-            address payable owner;
-            address storefront;
-        }
-
-        mapping(address => mapping(uint => Favourite)) internal favourites;
-        mapping(address => uint) internal favouriteCount;
-
-        function writeFavourite(address _storefront) public{
-            uint _favCount = readFavouriteCount(payable(msg.sender));
-
-            favourites[msg.sender][_favCount] = Favourite(
-                payable(msg.sender),
-                _storefront
-            );
-            favouriteCount[_storefront]++;
-        }
-
-        function readFavouriteCount(address payable _storeFront) public view returns(uint FavouriteCount){
-            return favouriteCount[_storeFront];
-        }
-
-        function readFavourite(uint index) public view returns(
-            address storefront
-        ){
-            return favourites[msg.sender][index].storefront;
-        }
-
-
         struct OrderItem {
             string ProductName;
             uint Quantity;
@@ -360,7 +331,7 @@
         }
 
         function readFresaProductCount() public view returns(uint NetworkProductCount){
-            return fresaStoreCount;
+            return fresaProductCount;
         }
 
         function readFresaSaleCount() public view returns(uint NetworkSaleCount){


### PR DESCRIPTION
Removed the favourite functionality and corresponding data structures.
Fixed `readFresaProductCount()` function to return the product count.